### PR TITLE
modified code to work with auto layout

### DIFF
--- a/OneTimePasswordView/OneTimePasswordTextField.swift
+++ b/OneTimePasswordView/OneTimePasswordTextField.swift
@@ -9,17 +9,7 @@ import UIKit
 
 class OneTimePasswordTextField: UIView {
 
-    var maxWidth: CGFloat! {
-        didSet {
-            numberWidth = (maxWidth - 20 - 20) / 6
-        }
-    }
-    var numberWidth: CGFloat = 44 {
-        didSet {
-            cstrUnderLineMarkWidth.constant = numberWidth
-            layoutIfNeeded()
-        }
-    }
+    var numberWidth: CGFloat = 44
     
     @IBOutlet private weak var cstrUnderLineMarkWidth: NSLayoutConstraint!
     @IBOutlet private weak var cstrUnderLineMarkLeading: NSLayoutConstraint!
@@ -50,6 +40,18 @@ class OneTimePasswordTextField: UIView {
         lblNumber4.text = ""
         lblNumber5.text = ""
         lblNumber6.text = ""
+    }
+    
+    // figure out width of view, adjust number widths
+    override func layoutSubviews() {
+        numberWidth = (self.bounds.width - 20 - 20) / 6
+        cstrUnderLineMarkWidth.constant = numberWidth
+        super.layoutSubviews()
+    }
+
+    // mainly to return minimum height to display numbers
+    override func intrinsicContentSize() -> CGSize {
+        return CGSize(width: 100, height: 114)
     }
     
     private func underlinePosition(range: NSRange) {


### PR DESCRIPTION
Use this or not - I liked your class and found it very easy to change the code for auto layout.

I had the following problems making it work with AutoLayout:
- Width of the component was set in a variable - when the width changes depending on auto layout, then that's not an option. 
- Height of the component was very small, then growing when I entered the letters. I realized this was because the size to fit the content is default, and while there are no numbers that size is small. Auto layout was smart enough to adjust component height when I was typing (even animated!) - but I don't want that, I want it to stay the same height. 

Solution: Removed maxWidth variable,  override layoutSubviews to figure out size, override intrinsicContentSize to start with a height large enough to cover all. Works well.

Probably took me more time to write this comment than to make those changes ;)